### PR TITLE
Releasing and publishing to maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,23 @@ jobs:
       SPHA_VERSION: ${{ inputs.tag || github.ref_name }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
         with:
           ref: ${{ env.SPHA_VERSION }}
 
 
       - name: Generate Release Notes
         run: ./gradlew -q printChangeLog > RELEASE_NOTES.md
+
+      - name: Publish to OSSRH
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED: true
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          SONATYPE_CONNECT_TIMEOUT_SECONDS: 300
+        run: ./gradlew --no-configuration-cache publishAndReleaseToMavenCentral
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
 
       - name: Publish to OSSRH
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PW }}
           ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED: true
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
           SONATYPE_CONNECT_TIMEOUT_SECONDS: 300
         run: ./gradlew --no-configuration-cache publishAndReleaseToMavenCentral
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,7 +21,8 @@ repositories {
 
 dependencies {
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
-
+    implementation(libs.plugin.mavenPublish)
+    implementation(libs.plugin.dokkatoo)
     implementation(libs.plugin.kotlin)
     implementation(libs.plugin.ktfmt)
 }

--- a/buildSrc/src/main/kotlin/spha-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/spha-kotlin-conventions.gradle.kts
@@ -19,6 +19,7 @@ plugins {
     id("dev.adamko.dokkatoo")
     kotlin("jvm")
     id("com.ncorti.ktfmt.gradle")
+    id("spha-release-conventions")
 }
 
 repositories { mavenCentral() }
@@ -72,9 +73,4 @@ tasks.register<Jar>("javadocJar") {
     dependsOn(tasks.dokkatooGeneratePublicationJavadoc)
     from(tasks.dokkatooGeneratePublicationJavadoc.flatMap { it.outputDirectory })
     archiveClassifier = "javadoc"
-}
-
-tasks.register<Jar>("sourcesJar") {
-    archiveClassifier = "sources"
-    from(sourceSets.main.get().allSource)
 }

--- a/buildSrc/src/main/kotlin/spha-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/spha-kotlin-conventions.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     // Apply core plugins.
     jacoco
     `java-library`
-
+    id("dev.adamko.dokkatoo")
     kotlin("jvm")
     id("com.ncorti.ktfmt.gradle")
 }
@@ -63,4 +63,18 @@ tasks.register("jacocoReport") {
     group = "Reporting"
 
     dependsOn(tasks.withType<JacocoReport>())
+}
+
+tasks.register<Jar>("javadocJar") {
+    description = "Assembles a JAR containing the Javadoc documentation."
+    group = "Documentation"
+
+    dependsOn(tasks.dokkatooGeneratePublicationJavadoc)
+    from(tasks.dokkatooGeneratePublicationJavadoc.flatMap { it.outputDirectory })
+    archiveClassifier = "javadoc"
+}
+
+tasks.register<Jar>("sourcesJar") {
+    archiveClassifier = "sources"
+    from(sourceSets.main.get().allSource)
 }

--- a/buildSrc/src/main/kotlin/spha-release-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/spha-release-conventions.gradle.kts
@@ -17,11 +17,7 @@ plugins {
 }
 
 mavenPublishing {
-    fun getGroupId(parent: Project?): String =
-        parent?.let { "${getGroupId(it.parent)}.${it.name.replace("-", "")}" }.orEmpty()
-
-    coordinates(groupId = "org${getGroupId(parent)}")
-    publishToMavenCentral()
+    coordinates(groupId = "de.fraunhofer.iem", artifactId = "spha", version = version.toString())
 
     configure(
         KotlinJvm(

--- a/buildSrc/src/main/kotlin/spha-release-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/spha-release-conventions.gradle.kts
@@ -1,0 +1,74 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinJvm
+import com.vanniktech.maven.publish.SonatypeHost
+
+/*
+ * Copyright (c) 2024 Fraunhofer IEM. All rights reserved.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ *
+ * SPDX-License-Identifier: MIT
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    // Apply third-party plugins.
+    id("com.vanniktech.maven.publish")
+}
+
+mavenPublishing {
+    fun getGroupId(parent: Project?): String =
+        parent?.let { "${getGroupId(it.parent)}.${it.name.replace("-", "")}" }.orEmpty()
+
+    coordinates(groupId = "org${getGroupId(parent)}")
+    publishToMavenCentral()
+
+    configure(
+        KotlinJvm(
+            // configures the -javadoc artifact, possible values:
+            // - `JavadocJar.None()` don't publish this artifact
+            // - `JavadocJar.Empty()` publish an empty jar
+            // - `JavadocJar.Dokka("dokkaHtml")` when using Kotlin with Dokka, where `dokkaHtml` is
+            // the name of the Dokka task that should be used as input
+            javadocJar = JavadocJar.Dokka("dokkatooGeneratePublicationJavadoc"),
+            // whether to publish a sources jar
+            sourcesJar = true,
+        )
+    )
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    signAllPublications()
+
+    pom {
+        name = project.name
+        description =
+            "SPHA is a library to transform tool results into KPIs and calculate KPI hierarchies."
+        url = "https://github.com/fraunhofer-iem/software-product-health-analyzer"
+
+        developers {
+            developer {
+                name = "Fraunhofer IEM"
+                email = "jan-niclas.struewer@iem.fraunhofer.de"
+                url =
+                    "https://github.com/fraunhofer-iem/software-product-health-analyzer/graphs/contributors"
+            }
+        }
+
+        licenses {
+            license {
+                name = "MIT"
+                url =
+                    "https://github.com/fraunhofer-iem/software-product-health-analyzer/blob/main/LICENSE.md"
+            }
+        }
+
+        scm {
+            connection =
+                "scm:git:https://github.com/fraunhofer-iem/software-product-health-analyzer.git"
+            developerConnection =
+                "scm:git:git@github.com:fraunhofer-iem/software-product-health-analyzer.git"
+            tag = version.toString()
+            url = "https://github.com/fraunhofer-iem/software-product-health-analyzer"
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ mockk = "1.13.13"
 semver = "2.0.0"
 kotlinDate = "0.6.1"
 ktfmtPlugin = "0.20.1"
+mavenPublishPlugin = "0.30.0"
+dokkatooPlugin = "2.4.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -22,7 +24,8 @@ plugin-ktfmt = { module = "com.ncorti.ktfmt.gradle:plugin", version.ref = "ktfmt
 semver = { module = "io.github.z4kn4fein:semver", version.ref = "semver" }
 test-junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 test-mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
-
+plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishPlugin" }
+plugin-dokkatoo = { module = "dev.adamko.dokkatoo:dokkatoo-plugin", version.ref = "dokkatooPlugin" }
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
This PR adds the Gradle publishing plugin to push SPHA to maven central. Therefore, we also added the dokkatoo plugin to generate javadoc for the released library.

The PR is kept as a draft until the necessary secrets have been set. 