### PR TITLE
ci: fix signed publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-22.04
+    environment: Deploy
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
         with:
@@ -33,10 +34,10 @@ jobs:
 
       - name: Publish to OSSRH
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: '${{ secrets.SONATYPE_USER }}'
-          ORG_GRADLE_PROJECT_mavenCentralPassword: '${{ secrets.SONATYPE_PW }}'
-          ORG_GRADLE_PROJECT_signingKey: '${{ secrets.GPG_PRIVATE_KEY }}'
-          ORG_GRADLE_PROJECT_signingPassword: '${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}'
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PW }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
         run: ./gradlew publish
 
       - name: Generate Release Notes

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,5 @@ gradle/**
 
 # Ignore kotlin files
 .kotlin
+
+**/bin


### PR DESCRIPTION
ci run (disabled gh release for this): https://github.com/fraunhofer-iem/software-product-health-analyzer/actions/runs/11519493124/job/32068617537
![image](https://github.com/user-attachments/assets/8999059d-c2ff-423d-bade-bb6d836c156e)
nexus:
![image](https://github.com/user-attachments/assets/d74f15ae-65e8-4d06-82cc-b2105288aea4)
