### PR TITLE
Enforce valid KpiResult scores

### DIFF
--- a/core/src/main/kotlin/de/fraunhofer/iem/spha/core/strategy/KpiCalculationStrategy.kt
+++ b/core/src/main/kotlin/de/fraunhofer/iem/spha/core/strategy/KpiCalculationStrategy.kt
@@ -154,21 +154,27 @@ internal abstract class BaseKpiCalculationStrategy : KpiCalculationStrategy {
     protected abstract fun internalIsValid(node: KpiNode, strict: Boolean): Boolean
 
     companion object {
+        /**
+         * Checks if `result.score` is in a valid range (0..100). If the score is lower 0 or higher
+         * than 100, we return 0 or 100 respectively.
+         *
+         * @param result
+         */
         fun getResultInValidRange(result: KpiCalculationResult): KpiCalculationResult {
             return when (result) {
                 is KpiCalculationResult.Success ->
-                    validateScore(result, result.score) { score ->
+                    createValidScore(result, result.score) { score ->
                         KpiCalculationResult.Success(score)
                     }
                 is KpiCalculationResult.Incomplete ->
-                    validateScore(result, result.score) { score ->
+                    createValidScore(result, result.score) { score ->
                         KpiCalculationResult.Incomplete(score, result.reason)
                     }
                 else -> result
             }
         }
 
-        private fun <T : KpiCalculationResult> validateScore(
+        private fun <T : KpiCalculationResult> createValidScore(
             result: T,
             score: Int,
             createResult: (Int) -> T,

--- a/core/src/main/kotlin/de/fraunhofer/iem/spha/core/strategy/KpiCalculationStrategy.kt
+++ b/core/src/main/kotlin/de/fraunhofer/iem/spha/core/strategy/KpiCalculationStrategy.kt
@@ -13,6 +13,7 @@ import de.fraunhofer.iem.spha.core.hierarchy.KpiHierarchyEdge
 import de.fraunhofer.iem.spha.model.kpi.KpiStrategyId
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiNode
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 internal fun getKpiCalculationStrategy(strategyId: KpiStrategyId): KpiCalculationStrategy {
     return when (strategyId) {
@@ -60,6 +61,8 @@ internal interface KpiCalculationStrategy {
     fun isValid(node: KpiNode, strict: Boolean = false): Boolean
 }
 
+private val logger = KotlinLogging.logger {}
+
 internal abstract class BaseKpiCalculationStrategy : KpiCalculationStrategy {
 
     abstract val kpiStrategyId: KpiStrategyId
@@ -82,7 +85,7 @@ internal abstract class BaseKpiCalculationStrategy : KpiCalculationStrategy {
 
         updateEdgeWeights(edges = hierarchyEdges, strict)
 
-        val result = internalCalculateKpi(hierarchyEdges)
+        val result = getResultInValidRange(internalCalculateKpi(hierarchyEdges))
 
         if (
             hierarchyEdges.any { it.to.result !is KpiCalculationResult.Success } &&
@@ -149,4 +152,38 @@ internal abstract class BaseKpiCalculationStrategy : KpiCalculationStrategy {
     }
 
     protected abstract fun internalIsValid(node: KpiNode, strict: Boolean): Boolean
+
+    companion object {
+        fun getResultInValidRange(result: KpiCalculationResult): KpiCalculationResult {
+            return when (result) {
+                is KpiCalculationResult.Success ->
+                    validateScore(result, result.score) { score ->
+                        KpiCalculationResult.Success(score)
+                    }
+                is KpiCalculationResult.Incomplete ->
+                    validateScore(result, result.score) { score ->
+                        KpiCalculationResult.Incomplete(score, result.reason)
+                    }
+                else -> result
+            }
+        }
+
+        private fun <T : KpiCalculationResult> validateScore(
+            result: T,
+            score: Int,
+            createResult: (Int) -> T,
+        ): T {
+            return when {
+                score < 0 -> {
+                    logger.warn { "Calculation result score $result is out of bounds." }
+                    createResult(0)
+                }
+                score > 100 -> {
+                    logger.warn { "Calculation result score $result is out of bounds." }
+                    createResult(100)
+                }
+                else -> result
+            }
+        }
+    }
 }

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/AbstractKpiCalculationTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/AbstractKpiCalculationTest.kt
@@ -18,6 +18,7 @@ import de.fraunhofer.iem.spha.model.kpi.RawValueKpi
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiEdge
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiNode
+import kotlin.random.Random
 import kotlin.test.fail
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -172,5 +173,54 @@ class AbstractKpiCalculationTest {
         assertEquals(0.0, incompleteNode.hierarchyEdges.first().actualWeight)
         assertEquals(0.5, incompleteNode.hierarchyEdges.last().plannedWeight)
         assertEquals(1.0, incompleteNode.hierarchyEdges.last().actualWeight)
+    }
+
+    @Test
+    fun isValidResultRange() {
+        (0..100).forEach { score ->
+            val successResult = KpiCalculationResult.Success(score)
+            val incompleteResult = KpiCalculationResult.Incomplete(score, "Incomplete")
+            assertEquals(
+                successResult,
+                BaseKpiCalculationStrategy.getResultInValidRange(successResult),
+            )
+            assertEquals(
+                incompleteResult,
+                BaseKpiCalculationStrategy.getResultInValidRange(incompleteResult),
+            )
+        }
+    }
+
+    @Test
+    fun isInvalidResultRange() {
+
+        val smallerThanZero = List(10) { Random.nextInt(-100, 0) }
+        val largerThanHundred = List(10) { Random.nextInt(101, 200) }
+
+        smallerThanZero.forEach { score ->
+            val successResult = KpiCalculationResult.Success(score)
+            val incompleteResult = KpiCalculationResult.Incomplete(score, "Incomplete")
+            assertEquals(
+                KpiCalculationResult.Success(0),
+                BaseKpiCalculationStrategy.getResultInValidRange(successResult),
+            )
+            assertEquals(
+                KpiCalculationResult.Incomplete(0, "Incomplete"),
+                BaseKpiCalculationStrategy.getResultInValidRange(incompleteResult),
+            )
+        }
+
+        largerThanHundred.forEach { score ->
+            val successResult = KpiCalculationResult.Success(score)
+            val incompleteResult = KpiCalculationResult.Incomplete(score, "Incomplete")
+            assertEquals(
+                KpiCalculationResult.Success(100),
+                BaseKpiCalculationStrategy.getResultInValidRange(successResult),
+            )
+            assertEquals(
+                KpiCalculationResult.Incomplete(100, "Incomplete"),
+                BaseKpiCalculationStrategy.getResultInValidRange(incompleteResult),
+            )
+        }
     }
 }

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/AbstractKpiCalculationTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/AbstractKpiCalculationTest.kt
@@ -223,4 +223,13 @@ class AbstractKpiCalculationTest {
             )
         }
     }
+
+    @Test
+    fun rangeCheckForNoScoreResults() {
+        val errorResult = KpiCalculationResult.Error("Error")
+        val emptyResult = KpiCalculationResult.Empty()
+
+        assertEquals(emptyResult, BaseKpiCalculationStrategy.getResultInValidRange(emptyResult))
+        assertEquals(errorResult, BaseKpiCalculationStrategy.getResultInValidRange(errorResult))
+    }
 }


### PR DESCRIPTION
feat: check the score of all KpiCalculationResults to guarantee that they are in the range of 0...100