### PR TITLE
fix: use PkgName and InstalledVersion to support non-OS targets

### DIFF
--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapter.kt
@@ -92,7 +92,7 @@ object TrivyAdapter {
 
             val score = getHighestCvssScore(cvssData)
             logger.trace { "Selected CVSS score $score for vulnerability '${it.vulnerabilityID}'" }
-            VulnerabilityDto(it.vulnerabilityID, it.pkgID, score)
+            VulnerabilityDto(it.vulnerabilityID, it.pkgName, score)
         }
     }
 

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapter.kt
@@ -91,8 +91,9 @@ object TrivyAdapter {
             val cvssData = it.cvss!!.values.map { jsonParser.decodeFromJsonElement<CVSSData>(it) }
 
             val score = getHighestCvssScore(cvssData)
+            val packageID = "${it.pkgName}@${it.installedVersion}"
             logger.trace { "Selected CVSS score $score for vulnerability '${it.vulnerabilityID}'" }
-            VulnerabilityDto(it.vulnerabilityID, it.pkgName, score)
+            VulnerabilityDto(it.vulnerabilityID, packageID, score)
         }
     }
 

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapterTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapterTest.kt
@@ -53,11 +53,11 @@ class TrivyAdapterTest {
     fun testResult2Dto() {
         Files.newInputStream(Path("src/test/resources/trivy-result-v2.json")).use {
             val dto = assertDoesNotThrow { TrivyAdapter.dtoFromJson(it) }
-            assertEquals(1, dto.vulnerabilities.count())
+            assertEquals(2, dto.vulnerabilities.count())
 
             val vuln = dto.vulnerabilities.first()
             assertEquals("CVE-2011-3374", vuln.cveIdentifier)
-            assertEquals("apt@2.6.1", vuln.packageName)
+            assertEquals("apt", vuln.packageName)
             assertEquals(4.3, vuln.severity)
         }
     }
@@ -69,7 +69,7 @@ class TrivyAdapterTest {
             assertEquals(2, dto.vulnerabilities.count())
 
             assertTrue { dto.vulnerabilities.all { it.cveIdentifier == "CVE-2005-2541" } }
-            assertEquals("tar@1.34+dfsg-1.2", dto.vulnerabilities.first().packageName)
+            assertEquals("tar", dto.vulnerabilities.first().packageName)
             assertEquals(10.0, dto.vulnerabilities.first().severity)
         }
     }

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapterTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapterTest.kt
@@ -57,7 +57,7 @@ class TrivyAdapterTest {
 
             val vuln = dto.vulnerabilities.first()
             assertEquals("CVE-2011-3374", vuln.cveIdentifier)
-            assertEquals("apt", vuln.packageName)
+            assertEquals("apt@2.6.1", vuln.packageName)
             assertEquals(4.3, vuln.severity)
         }
     }
@@ -69,7 +69,7 @@ class TrivyAdapterTest {
             assertEquals(2, dto.vulnerabilities.count())
 
             assertTrue { dto.vulnerabilities.all { it.cveIdentifier == "CVE-2005-2541" } }
-            assertEquals("tar", dto.vulnerabilities.first().packageName)
+            assertEquals("tar@1.34+dfsg-1.2", dto.vulnerabilities.first().packageName)
             assertEquals(10.0, dto.vulnerabilities.first().severity)
         }
     }

--- a/adapter/src/test/resources/trivy-result-v2.json
+++ b/adapter/src/test/resources/trivy-result-v2.json
@@ -129,6 +129,61 @@
           }
         }
       ]
+    },
+    {
+      "Target": "Python",
+      "Class": "lang-pkgs",
+      "Type": "python-pkg",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2024-22190",
+          "PkgName": "GitPython",
+          "PkgPath": "home/redacted/.local/lib/python3.11/site-packages/GitPython-3.1.37.dist-info/METADATA",
+          "PkgIdentifier": {
+            "PURL": "pkg:pypi/gitpython@3.1.37",
+            "UID": "5591a0dc57c78b2"
+          },
+          "InstalledVersion": "3.1.37",
+          "FixedVersion": "3.1.41",
+          "Status": "fixed",
+          "Layer": {
+            "Digest": "sha256:13b0acb9b68e8a74b8e6152932c5bd6c6968e13fa32feba83cc2310346a9b7f9",
+            "DiffID": "sha256:feea6321b4864eb2cb16188d1619323db7c8738adaca6982c8005da9fe227961"
+          },
+          "SeveritySource": "ghsa",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-22190",
+          "DataSource": {
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory pip",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Apip"
+          },
+          "Title": "Untrusted search path under some conditions on Windows allows arbitrary code execution",
+          "Description": "GitPython is a python library used to interact with Git repositories. There is an incomplete fix for CVE-2023-40590. On Windows, GitPython uses an untrusted search path if it uses a shell to run `git`, as well as when it runs `bash.exe` to interpret hooks. If either of those features are used on Windows, a malicious `git.exe` or `bash.exe` may be run from an untrusted repository. This issue has been patched in version 3.1.41.",
+          "Severity": "HIGH",
+          "CweIDs": [
+            "CWE-426"
+          ],
+          "VendorSeverity": {
+            "ghsa": 3,
+            "nvd": 3
+          },
+          "CVSS": {
+            "ghsa": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "V3Score": 7.8
+            },
+            "nvd": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "V3Score": 7.8
+            }
+          },
+          "References": [
+            "https://github.com/gitpython-developers/GitPython"
+          ],
+          "PublishedDate": "2024-01-11T02:15:48.25Z",
+          "LastModifiedDate": "2024-01-18T13:48:07.553Z"
+        }
+      ]
     }
   ]
 }

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/trivy/TrivyDto.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/trivy/TrivyDto.kt
@@ -43,10 +43,7 @@ data class TrivyVulnerabilityDto(
 )
 
 @Serializable
-data class PkgIdentifier(
-    @SerialName("PURL") val purl: String,
-    @SerialName("UID") val uid: String,
-)
+data class PkgIdentifier(@SerialName("PURL") val purl: String, @SerialName("UID") val uid: String)
 
 @Serializable
 data class CVSSData(

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/trivy/TrivyDto.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/trivy/TrivyDto.kt
@@ -38,7 +38,14 @@ data class TrivyVulnerabilityDto(
     // This way we can iterate over those when required. Their type is always CVSSData.
     @SerialName("CVSS") val cvss: JsonObject?,
     @SerialName("VulnerabilityID") val vulnerabilityID: String,
-    @SerialName("PkgID") val pkgID: String,
+    @SerialName("PkgIdentifier") val pkgID: PkgIdentifier,
+    @SerialName("PkgName") val pkgName: String,
+)
+
+@Serializable
+data class PkgIdentifier(
+    @SerialName("PURL") val purl: String,
+    @SerialName("UID") val uid: String,
 )
 
 @Serializable

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/trivy/TrivyDto.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/trivy/TrivyDto.kt
@@ -38,12 +38,9 @@ data class TrivyVulnerabilityDto(
     // This way we can iterate over those when required. Their type is always CVSSData.
     @SerialName("CVSS") val cvss: JsonObject?,
     @SerialName("VulnerabilityID") val vulnerabilityID: String,
-    @SerialName("PkgIdentifier") val pkgID: PkgIdentifier,
+    @SerialName("InstalledVersion") val installedVersion: String,
     @SerialName("PkgName") val pkgName: String,
 )
-
-@Serializable
-data class PkgIdentifier(@SerialName("PURL") val purl: String, @SerialName("UID") val uid: String)
 
 @Serializable
 data class CVSSData(

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/trivy/TrivyDto.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/trivy/TrivyDto.kt
@@ -40,6 +40,7 @@ data class TrivyVulnerabilityDto(
     @SerialName("VulnerabilityID") val vulnerabilityID: String,
     @SerialName("InstalledVersion") val installedVersion: String,
     @SerialName("PkgName") val pkgName: String,
+    @SerialName("Severity") val severity: String,
 )
 
 @Serializable


### PR DESCRIPTION
# Description

When running a trivy scan for https://gitlab.opencode.de/opencode-analyzer/occmd-public, I receive the following error:
```
ERROR de.fraunhofer.iem.podmanager.rabbitmq.Consumer - Field 'PkgID' is required for type with serial name 'de.fraunhofer.iem.spha.model.adapter.trivy.TrivyVulnerabilityDto', but it was missing at path: $.Results[0].Vulnerabilities[1]
```
This happened because the output of the Trivy scan contains Python packages without any `PkgID`, for example:
```
    {
      "Target": "Python",
      "Class": "lang-pkgs",
      "Type": "python-pkg",
      "Vulnerabilities": [
        {
          "VulnerabilityID": "CVE-2024-22190",
          "PkgName": "GitPython",
          "PkgPath": "home/redacted/.local/lib/python3.11/site-packages/GitPython-3.1.37.dist-info/METADATA",
          "PkgIdentifier": {
            "PURL": "pkg:pypi/gitpython@3.1.37",
            "UID": "5591a0dc57c78b2"
          },
          "InstalledVersion": "3.1.37",
          "FixedVersion": "3.1.41",
          "Status": "fixed",
          "Layer": {
            "Digest": "sha256:13b0acb9b68e8a74b8e6152932c5bd6c6968e13fa32feba83cc2310346a9b7f9",
            "DiffID": "sha256:feea6321b4864eb2cb16188d1619323db7c8738adaca6982c8005da9fe227961"
          },
          "SeveritySource": "ghsa",
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-22190",
          "DataSource": {
            "ID": "ghsa",
            "Name": "GitHub Security Advisory pip",
            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Apip"
          },
          "Title": "Untrusted search path under some conditions on Windows allows arbitrary code execution",
          "Description": "GitPython is a python library used to interact with Git repositories. There is an incomplete fix for CVE-2023-40590. On Windows, GitPython uses an untrusted search path if it uses a shell to run `git`, as well as when it runs `bash.exe` to interpret hooks. If either of those features are used on Windows, a malicious `git.exe` or `bash.exe` may be run from an untrusted repository. This issue has been patched in version 3.1.41.",
          "Severity": "HIGH",
          "CweIDs": [
            "CWE-426"
          ],
          "VendorSeverity": {
            "ghsa": 3,
            "nvd": 3
          },
          "CVSS": {
            "ghsa": {
              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
              "V3Score": 7.8
            },
            "nvd": {
              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
              "V3Score": 7.8
            }
          },
          "References": [
            "https://github.com/gitpython-developers/GitPython"
          ],
          "PublishedDate": "2024-01-11T02:15:48.25Z",
          "LastModifiedDate": "2024-01-18T13:48:07.553Z"
        }
      ]
    }
```

# Changes

This PR changes the Trivy Vulnerability Dto to get `PkgName` and `InstalledVersion` instead of `PkgID`, because these fields are always available regardless of scan target types. Tests are updated with this PR too.