### PR TITLE
feat: added timestamp to KpiResultHierarchy

### DIFF
--- a/core/src/main/kotlin/de/fraunhofer/iem/spha/core/hierarchy/KpiHierarchyNode.kt
+++ b/core/src/main/kotlin/de/fraunhofer/iem/spha/core/hierarchy/KpiHierarchyNode.kt
@@ -26,7 +26,9 @@ private constructor(
     val originId: String? = null,
     val reason: String? = null,
 ) {
-    var id: String = UUID.randomUUID().toString()
+    private var _id: String = UUID.randomUUID().toString()
+    val id: String
+        get() = _id
 
     constructor(
         typeId: String,
@@ -37,7 +39,7 @@ private constructor(
         originId: String? = null,
         reason: String? = null,
     ) : this(typeId, strategy, edges, tags, originId, reason) {
-        this.id = id
+        this._id = id
     }
 
     var result: KpiCalculationResult = KpiCalculationResult.Empty()

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/RawValueKpi.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/RawValueKpi.kt
@@ -10,6 +10,7 @@
 package de.fraunhofer.iem.spha.model.kpi
 
 import java.util.UUID
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -22,7 +23,9 @@ data class RawValueKpi(
     val originId: String? = null,
 ) {
     // Used to uniquely identify the given instance
-    var id: String = UUID.randomUUID().toString()
+    @SerialName("id") private var _id: String = UUID.randomUUID().toString()
+    val id: String
+        get() = _id
 
     constructor(
         typeId: String,
@@ -30,6 +33,6 @@ data class RawValueKpi(
         id: String,
         originId: String? = null,
     ) : this(typeId, score, originId) {
-        this.id = id
+        this._id = id
     }
 }

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultHierarchy.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultHierarchy.kt
@@ -13,13 +13,14 @@ import de.fraunhofer.iem.spha.model.kpi.KpiStrategyId
 import java.util.UUID
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @ConsistentCopyVisibility
 @Serializable
 data class KpiResultHierarchy
 private constructor(val root: KpiResultNode, val schemaVersion: String) {
-    @OptIn(ExperimentalTime::class) var timestamp: String = Clock.System.now().toString()
+    @OptIn(ExperimentalTime::class) val timestamp: String = Clock.System.now().toString()
 
     companion object {
         fun create(rootNode: KpiResultNode) = KpiResultHierarchy(rootNode, SCHEMA_VERSIONS.last())
@@ -36,7 +37,9 @@ data class KpiResultNode(
     val originId: String? = null,
     val reason: String? = null,
 ) {
-    var id: String = UUID.randomUUID().toString()
+    @SerialName("id") private var _id: String = UUID.randomUUID().toString()
+    val id: String
+        get() = _id
 
     constructor(
         typeId: String,
@@ -56,7 +59,7 @@ data class KpiResultNode(
         originId = originId,
         reason = reason,
     ) {
-        this.id = id
+        this._id = id
     }
 }
 

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiResultHierarchyTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiResultHierarchyTest.kt
@@ -81,8 +81,7 @@ class JsonKpiResultHierarchyTest {
             )
 
         val hierarchy = KpiResultHierarchy.create(root)
-        // Set a fixed timestamp for deterministic testing
-        hierarchy.timestamp = "2025-06-24T11:18:32.774067Z"
+
         val jsonResult = Json.Default.encodeToString(hierarchy)
 
         println(jsonResult)
@@ -91,7 +90,7 @@ class JsonKpiResultHierarchyTest {
         // This implicitly asserts that KpiResultNode and KpiResultEdge get serialized to the
         // expected JSON too
         val expected =
-            "{\"root\":{\"typeId\":\"ROOT\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"MAXIMUM_STRATEGY\",\"edges\":[{\"target\":{\"typeId\":\"CODE_VULNERABILITY_SCORE\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"RAW_VALUE_STRATEGY\",\"edges\":[],\"tags\":[\"A\",\"B\",\"a\",\"b\"],\"originId\":\"someOrigin\",\"reason\":\"CRA relevant\",\"id\":\"cveId\"},\"plannedWeight\":1.0,\"actualWeight\":0.5}],\"id\":\"rootId\"},\"schemaVersion\":\"1.1.0\",\"timestamp\":\"2025-06-24T11:18:32.774067Z\"}"
+            "{\"root\":{\"typeId\":\"ROOT\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"MAXIMUM_STRATEGY\",\"edges\":[{\"target\":{\"typeId\":\"CODE_VULNERABILITY_SCORE\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"RAW_VALUE_STRATEGY\",\"edges\":[],\"tags\":[\"A\",\"B\",\"a\",\"b\"],\"originId\":\"someOrigin\",\"reason\":\"CRA relevant\",\"id\":\"cveId\"},\"plannedWeight\":1.0,\"actualWeight\":0.5}],\"id\":\"rootId\"},\"schemaVersion\":\"1.1.0\",\"timestamp\":\"${hierarchy.timestamp}\"}"
 
         kotlin.test.assertEquals(expected, jsonResult)
     }


### PR DESCRIPTION
Added timestamp to KpiResultHierarchy.
I choose an Instant as an underlying data type because the use case description of the kotlin time library fit this perfectly.

<img width="849" alt="image" src="https://github.com/user-attachments/assets/e4da944d-bb12-488b-8bc6-532eff3d2ae6" />

Further change: changed id implementation to use backing properties to keep id out of the primary constructor and still have id immutable.
Explanation backing property: https://kotlinlang.org/docs/properties.html#backing-properties
