### PR TITLE
feat: add `createdAt` timestamp to `SphaToolResult` and update databa…

### DIFF
--- a/cli/src/main/kotlin/de/fraunhofer/iem/spha/cli/commands/AnalyzeRepositoryCommand.kt
+++ b/cli/src/main/kotlin/de/fraunhofer/iem/spha/cli/commands/AnalyzeRepositoryCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Fraunhofer IEM. All rights reserved.
+ * Copyright (c) 2025-2026 Fraunhofer IEM. All rights reserved.
  *
  * Licensed under the MIT license. See LICENSE file in the project root for details.
  *
@@ -29,6 +29,7 @@ import java.nio.file.FileSystem
 import kotlin.io.path.createDirectories
 import kotlin.io.path.inputStream
 import kotlin.io.path.outputStream
+import kotlin.time.Clock
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
@@ -166,7 +167,7 @@ internal class AnalyzeRepositoryCommand :
                 }
             }
 
-        val result = SphaToolResult(kpiResult, originsData, projectInfo)
+        val result = SphaToolResult(kpiResult, originsData, projectInfo, Clock.System.now())
         processResult(result)
     }
 

--- a/lib/model/src/main/kotlin/de/fraunhofer/iem/spha/model/SphaToolResult.kt
+++ b/lib/model/src/main/kotlin/de/fraunhofer/iem/spha/model/SphaToolResult.kt
@@ -13,6 +13,7 @@ import de.fraunhofer.iem.spha.model.adapter.Origin
 import de.fraunhofer.iem.spha.model.adapter.ToolInfo
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiResultHierarchy
 import de.fraunhofer.iem.spha.model.project.ProjectInfo
+import kotlin.time.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -20,6 +21,7 @@ data class SphaToolResult(
     val resultHierarchy: KpiResultHierarchy,
     val origins: List<ToolInfoAndOrigin>,
     val projectInfo: ProjectInfo,
+    val createdAt: Instant,
 )
 
 @Serializable data class ToolInfoAndOrigin(val toolInfo: ToolInfo, val origins: List<Origin>)

--- a/server/src/main/kotlin/Databases.kt
+++ b/server/src/main/kotlin/Databases.kt
@@ -158,7 +158,7 @@ class ResultService(private val connection: Connection) {
                     value = hierarchyJson
                 },
             )
-            resultStmt.setTimestamp(3, Timestamp(System.currentTimeMillis()))
+            resultStmt.setTimestamp(3, Timestamp(result.createdAt.toEpochMilliseconds()))
             resultStmt.executeUpdate()
 
             val generatedKeys = resultStmt.generatedKeys
@@ -250,6 +250,7 @@ class ResultService(private val connection: Connection) {
             while (resultsSet.next()) {
                 val resultId = resultsSet.getInt("ID")
                 val resultHierarchyJson = resultsSet.getString("RESULT_HIERARCHY")
+                val createdAtTimestamp = resultsSet.getTimestamp("CREATED_AT")
 
                 // Get tool info and origins for this result
                 val toolInfoStmt =
@@ -274,6 +275,8 @@ class ResultService(private val connection: Connection) {
                         resultHierarchy = resultHierarchy,
                         origins = origins,
                         projectInfo = projectInfo,
+                        createdAt =
+                            kotlin.time.Instant.fromEpochMilliseconds(createdAtTimestamp.time),
                     )
                 )
             }

--- a/server/src/test/kotlin/ApplicationTest.kt
+++ b/server/src/test/kotlin/ApplicationTest.kt
@@ -88,6 +88,7 @@ class ReportEndpointTest {
             resultHierarchy = createTestKpiResultHierarchy(),
             origins = listOf(ToolInfoAndOrigin(toolInfo = toolInfo, origins = emptyList())),
             projectInfo = createTestProjectInfo(name = projectName, url = projectUrl),
+            createdAt = kotlin.time.Instant.fromEpochMilliseconds(System.currentTimeMillis()),
         )
     }
 
@@ -250,6 +251,7 @@ class ReportEndpointTest {
                 resultHierarchy = KpiResultHierarchy.create(minimalNode),
                 origins = emptyList(),
                 projectInfo = minimalProjectInfo,
+                createdAt = kotlin.time.Instant.fromEpochMilliseconds(System.currentTimeMillis()),
             )
 
         val response =
@@ -348,6 +350,7 @@ class ReportEndpointTest {
                         ),
                     ),
                 projectInfo = createTestProjectInfo(name = "complex-project"),
+                createdAt = kotlin.time.Instant.fromEpochMilliseconds(System.currentTimeMillis()),
             )
 
         val response =
@@ -387,6 +390,7 @@ class ReportEndpointTest {
                 resultHierarchy = KpiResultHierarchy.create(errorNode),
                 origins = emptyList(),
                 projectInfo = createTestProjectInfo(name = "error-project"),
+                createdAt = kotlin.time.Instant.fromEpochMilliseconds(System.currentTimeMillis()),
             )
 
         val response =

--- a/server/src/test/kotlin/GetProjectsTest.kt
+++ b/server/src/test/kotlin/GetProjectsTest.kt
@@ -88,6 +88,7 @@ class ProjectsEndpointTest {
             resultHierarchy = createTestKpiResultHierarchy(),
             origins = listOf(ToolInfoAndOrigin(toolInfo = toolInfo, origins = emptyList())),
             projectInfo = createTestProjectInfo(name = projectName, url = projectUrl),
+            createdAt = kotlin.time.Instant.fromEpochMilliseconds(System.currentTimeMillis()),
         )
     }
 
@@ -354,6 +355,8 @@ class ProjectsEndpointTest {
                         ),
                     projectInfo =
                         createTestProjectInfo(name = "complex-structure", url = projectUrl),
+                    createdAt =
+                        kotlin.time.Instant.fromEpochMilliseconds(System.currentTimeMillis()),
                 )
 
             val createResponse =


### PR DESCRIPTION
…se logic

- Introduced `createdAt` field to `SphaToolResult` model and updated test data accordingly.
- Adjusted database schema and query logic to handle the new timestamp field.
- Updated affected classes to initialize or process the `createdAt` field.